### PR TITLE
Update formatting standard

### DIFF
--- a/_pages/coding_standard.md
+++ b/_pages/coding_standard.md
@@ -10,7 +10,7 @@ We decided to keep the coding standard simple so you can worry less about the st
   
 2. You must use [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) to format your code with the following options: 
   ```
-  { BasedOnStyle: LLVM, UseTab: Never, IndentWidth: 4, TabWidth: 4, ColumnLimit: 100 }
+  { BasedOnStyle: LLVM, UseTab: Never, IndentWidth: 4, TabWidth: 4, ColumnLimit: 100, InsertBraces: true }
   ```
   We will show you how to use this in one of your labs. Set it up to run on save.
 


### PR DESCRIPTION
@christopolise Are you okay with me adding `InsertBraces: true`? It will take this code:

```c
if (argc == 1)
        printf("test\n");
```

And add braces:

```c
if (argc == 1) {
        printf("test\n");
    }
```

It could potentially lead to wrong results because Clang Format doesn't always know where to add braces, but I like the idea of forcing students to always put braces because **I** think that is the right way of doing it 😉 