### PR TITLE
Remove early mention of `uint8_t`

### DIFF
--- a/_labs/data.md
+++ b/_labs/data.md
@@ -114,9 +114,9 @@ int main()
 
 I can expect that the program will print out `5` because the **return value** that the `sum()` provided was an `int` which was the sum  of `a + b`.
 
-If I wanted to have my value return the value as a `uint8_t`, I would rewrite the signature of my function as:
+If I wanted to have my value return the value as a `float`, I would rewrite the signature of my function as:
 ```c
-uint8_t sum(int a, int b)
+float sum(float a, float b)
 {
     return a + b;
 }


### PR DESCRIPTION
In that point of the lab, they haven't learned about `uint8_t` and having two `int`s as parameters but returning a `uint8_t` is a bad idea.