### PR TITLE
Fix Sass deprecation warnings: migrate to @use/@forward

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,6 +15,11 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css"
     integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous">
 
+<!-- Google Fonts -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono&family=Inter:wght@300;400;700&family=Roboto&display=swap">
+
 <!-- Custom styles for this template -->
 <link rel="stylesheet" href={{ "/css/main.css" | relative_url }}>
 

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -1,3 +1,6 @@
+@use "sass:color";
+@use "variables" as *;
+
 /**
  * Reset some basic elements
  */

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -125,7 +125,7 @@ a {
     }
 
     &:hover {
-        color: darken($brand-color, 15%);
+        color: color.adjust($brand-color, $lightness: -15%);
         text-decoration: underline;
     }
 }

--- a/_sass/_pages.scss
+++ b/_sass/_pages.scss
@@ -1,3 +1,5 @@
+@use "variables" as *;
+
 ::selection {
     // background-color: rgba(237, 63, 149, .2);
     background-color: $selection-color;

--- a/_sass/_syntax-highlighting-fruity.scss
+++ b/_sass/_syntax-highlighting-fruity.scss
@@ -3,7 +3,7 @@
  */
 .highlight {
     background: #fff;
-    @extend %vertical-rhythm;
+    margin-bottom: 15px;
 
     .highlighter-rouge & {
       background: #000;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -1,0 +1,44 @@
+@use "sass:color";
+
+// Typography
+$base-font-family: sans-serif !default;
+$header-font-family: sans-serif !default;
+$base-font-size: 16px !default;
+$base-font-weight: 300 !default;
+$small-font-size: $base-font-size * 0.875 !default;
+$base-line-height: 1.5 !default;
+
+// Spacing
+$spacing-unit: 30px !default;
+
+// Colors — static
+$grey-color: #424242 !default;
+$grey-color-light: color.adjust($grey-color, $lightness: 40%) !default;
+$grey-color-dark: color.adjust($grey-color, $lightness: -25%) !default;
+
+// Colors — configured from main.scss via @use "variables" with (...)
+$text-color: #ddd !default;
+$frame-color: #333 !default;
+$background-color: #222 !default;
+$brand-color: #60B3BE !default;
+$secondary-color: #52439B !default;
+$selection-color: #FEF081 !default;
+$sidebar-hover-color: #7D5FA9 !default;
+
+// Layout
+$content-width: 800px !default;
+
+// Breakpoints
+$on-palm: 600px !default;
+$on-laptop: 800px !default;
+$on-xs: 575.98px !default;
+$on-sm: 767.98px !default;
+$on-md: 991.98px !default;
+$on-lg: 1199.98px !default;
+
+// Mixins
+@mixin media-query($device) {
+    @media screen and (max-width: $device) {
+        @content;
+    }
+}

--- a/_sass/simple-sidebar.scss
+++ b/_sass/simple-sidebar.scss
@@ -1,3 +1,5 @@
+@use "variables" as *;
+
 /*!
  * Start Bootstrap - Simple Sidebar (https://startbootstrap.com/template-overviews/simple-sidebar)
  * Copyright 2013-2019 Start Bootstrap

--- a/css/main.scss
+++ b/css/main.scss
@@ -3,62 +3,24 @@
 ---
 
 @charset "utf-8";
-@use "sass:color";
-@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Inter&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+@use "variables" with (
+    $base-font-family: ({{ site.fonts.base }}),
+    $header-font-family: ({{ site.fonts.header }}),
+    $text-color: {{ site.colors.text_color }},
+    $frame-color: {{ site.colors.frame_color }},
+    $background-color: {{ site.colors.background_color }},
+    $brand-color: {{ site.colors.brand_color }},
+    $secondary-color: {{ site.colors.secondary_color }},
+    $selection-color: {{ site.colors.text_selection_color }},
+    $sidebar-hover-color: {{ site.colors.sidebar_hover_color }}
+);
+@use "base";
+@use "fonts";
+@use "syntax-highlighting-fruity";
+@use "simple-sidebar";
+@use "pages";
 
 strong {
     font-weight: 700;
     color: #daa520;
 }
-
-// Our variables
-$base-font-family: {{ site.fonts.base}};
-$header-font-family: {{ site.fonts.header }};
-$base-font-size: 16px;
-$base-font-weight: 300;
-$small-font-size: $base-font-size * 0.875;
-$base-line-height: 1.5;
-
-$spacing-unit: 30px;
-
-$text-color: {{ site.colors.text_color }};
-$frame-color: {{ site.colors.frame_color }};
-$background-color: {{ site.colors.background_color }};
-$brand-color: {{ site.colors.brand_color }};
-$secondary-color: {{ site.colors.secondary_color }};
-
-$selection-color: {{ site.colors.text_selection_color }};
-$sidebar-hover-color: {{ site.colors.sidebar_hover_color }};
-
-$grey-color: #424242;
-$grey-color-light: color.adjust($grey-color, $lightness: 40%);
-$grey-color-dark: color.adjust($grey-color, $lightness: -25%);
-
-// Width of the content area
-$content-width: 800px;
-
-$on-palm: 600px;
-$on-laptop: 800px;
-$on-xs: 575.98px;
-$on-sm: 767.98px;
-$on-md: 991.98px;
-$on-lg: 1199.98px;
-
-// Use media queries like this:
-// @include media-query($on-palm) {
-//     .wrapper {
-//         padding-right: $spacing-unit / 2;
-//         padding-left: $spacing-unit / 2;
-//     }
-// }
-@mixin media-query($device) {
-    @media screen and (max-width: $device) {
-        @content;
-    }
-}
-
-// Import partials from `sass_dir` (defaults to `_sass`)
-@import "base", "fonts", "syntax-highlighting-fruity", "simple-sidebar", "pages";

--- a/css/main.scss
+++ b/css/main.scss
@@ -3,6 +3,7 @@
 ---
 
 @charset "utf-8";
+@use "sass:color";
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Inter&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
@@ -33,8 +34,8 @@ $selection-color: {{ site.colors.text_selection_color }};
 $sidebar-hover-color: {{ site.colors.sidebar_hover_color }};
 
 $grey-color: #424242;
-$grey-color-light: lighten($grey-color, 40%);
-$grey-color-dark: darken($grey-color, 25%);
+$grey-color-light: color.adjust($grey-color, $lightness: 40%);
+$grey-color-dark: color.adjust($grey-color, $lightness: -25%);
 
 // Width of the content area
 $content-width: 800px;


### PR DESCRIPTION
## Summary

- Replace deprecated `lighten()`/`darken()` color functions with `color.adjust()` from the `sass:color` module
- Migrate all Sass `@import` rules to the modern `@use`/`@forward` module system, eliminating all remaining deprecation warnings

## Details

### Color functions (commit 1)
Dart Sass 3 removes the global `lighten()` and `darken()` built-ins. Replaced with `color.adjust()` using the `sass:color` module.

### @import migration (commit 2)
The `@use` module system doesn't share a global scope, so a few structural changes were needed:

- **`_sass/_variables.scss`** (new) — all variables and the `media-query` mixin, marked `!default` so `main.scss` can configure them with Liquid-derived values via `@use "variables" with (...)`
- **`css/main.scss`** — uses `@use "variables" with (...)` to inject Jekyll config values; `@use` replaces `@import` for all partials; font stacks wrapped in `()` to avoid comma ambiguity in `with ()` syntax
- **`_sass/_base.scss`, `_pages.scss`, `simple-sidebar.scss`** — each adds `@use "variables" as *`
- **`_sass/_syntax-highlighting-fruity.scss`** — cross-module `@extend` is not permitted under `@use`; replaced `@extend %vertical-rhythm` with the equivalent `margin-bottom: 15px`
- **`_includes/head.html`** — Google Fonts moved from Sass `@import url()` to `<link>` tags (CSS `@import` must precede other rules, but `@use` must come first in Sass source — these constraints are incompatible)

## Test plan

- [x] `bundle exec jekyll build` completes with zero deprecation warnings
- [ ] Visually verify fonts and colors render correctly on the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)